### PR TITLE
Removed wordpress plugin button until it gets updated to prevent misuse

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,13 +31,13 @@
                 <img class="nav__img" src="img/hideIcon.svg" />
                 <h2 class="nav__title">Hide Code Generator</h2>
             </div>
-            <div class="nav__item nav__item--download">
+            <!-- <div class="nav__item nav__item--download">
                 <div class="nav__update">New version available
                     <span>+</span>
                 </div>
                 <img class="nav__img" src="img/pluginIcon.svg" />
                 <h2 class="nav__title">Wordpress Plugin</h2>
-            </div>
+            </div> -->
         </div>
         <!--nav-->
 


### PR DESCRIPTION
Currently the wordpress plugin isn't working as intended. So to prevent anyone mistakenly sending it to someone, I have commented it out of the nav. 